### PR TITLE
Complete OAuth 2.1 implementation with MusicKit authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,27 @@ APPLE_TEAM_ID=your_team_id_here
 APPLE_KEY_ID=your_key_id_here
 APPLE_PRIVATE_KEY_PATH=/keys/AuthKey.p8
 
+# Apple Music OAuth (for user tokens)
+APPLE_CLIENT_ID=your_apple_client_id
+APPLE_CLIENT_SECRET=your_apple_client_secret
+
 # Server Configuration
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080
 DEBUG=false
+OAUTH_BASE_URL=http://localhost:8080
+
+# Database
+DATABASE_URL=sqlite:///./data/apple_music.db
+
+# OAuth Security (generate these keys!)
+JWT_SECRET_KEY=your_strong_random_secret_key
+TOKEN_ENCRYPTION_KEY=your_fernet_encryption_key
+
+# Token Lifetimes
+ACCESS_TOKEN_LIFETIME=3600
+REFRESH_TOKEN_LIFETIME=2592000
+AUTHORIZATION_CODE_LIFETIME=600
 
 # Rate Limiting
 RATE_LIMIT_REQUESTS=100

--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,8 @@ htmlcov/
 .tox/
 
 # Data directories
-data/
+data/*
+!data/.gitkeep
 cache/
+*.db
+*.sqlite

--- a/app/api/endpoints/oauth.py
+++ b/app/api/endpoints/oauth.py
@@ -1,0 +1,492 @@
+from fastapi import APIRouter, HTTPException, Depends, Query, Form
+from fastapi.responses import RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+from urllib.parse import urlencode
+import uuid
+import time
+import jwt
+import hashlib
+import base64
+import re
+from datetime import datetime, timedelta
+
+from app.core.database import get_db
+from app.core.config import settings
+from app.core.security import encrypt_token, decrypt_token
+from app.models.oauth import OAuth2Client, AuthorizationRequest, AuthorizationCodeGrant, AccessToken
+
+router = APIRouter()
+
+# Pydantic models for OAuth requests/responses
+class ClientRegistrationRequest(BaseModel):
+    redirect_uris: List[str]
+    client_name: Optional[str] = None
+    grant_types: Optional[List[str]] = ["authorization_code", "refresh_token"]
+    response_types: Optional[List[str]] = ["code"]
+    scope: Optional[str] = None
+    token_endpoint_auth_method: Optional[str] = "none"
+
+class ClientRegistrationResponse(BaseModel):
+    client_id: str
+    client_id_issued_at: int
+    redirect_uris: List[str]
+    grant_types: List[str]
+    response_types: List[str] 
+    token_endpoint_auth_method: str
+    client_name: Optional[str] = None
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "Bearer"
+    expires_in: int
+    refresh_token: Optional[str] = None
+    scope: Optional[str] = None
+
+@router.get("/.well-known/oauth-authorization-server")
+async def oauth_metadata():
+    """
+    OAuth 2.1 Authorization Server Metadata (RFC 8414)
+    Claude uses this for automatic endpoint discovery
+    """
+    return {
+        "issuer": settings.oauth_base_url,
+        "authorization_endpoint": f"{settings.oauth_base_url}/oauth/authorize",
+        "token_endpoint": f"{settings.oauth_base_url}/oauth/token",
+        "registration_endpoint": f"{settings.oauth_base_url}/oauth/register",
+        "revocation_endpoint": f"{settings.oauth_base_url}/oauth/revoke",
+        "scopes_supported": [
+            "library:read",
+            "library:write", 
+            "playlists:read",
+            "playlists:write",
+            "recently-played:read"
+        ],
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "token_endpoint_auth_method": "none",
+        "require_pushed_authorization_requests": False
+    }
+
+@router.post("/oauth/register", response_model=ClientRegistrationResponse)
+async def dynamic_client_registration(
+    request: ClientRegistrationRequest,
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    Dynamic Client Registration (RFC 7591)
+    Claude will call this to register itself as an OAuth client
+    """
+    
+    # Generate unique client ID
+    client_id = str(uuid.uuid4())
+    client_issued_at = int(time.time())
+    
+    # Validate redirect URIs - Claude typically uses localhost ports or claude.ai domains
+    allowed_patterns = [
+        r"^http://localhost:\d+/.*$",
+        r"^http://127\.0\.0\.1:\d+/.*$", 
+        r"^https://claude\.ai/.*$",
+        r"^https://.*\.claude\.ai/.*$"
+    ]
+    
+    for uri in request.redirect_uris:
+        if not any(re.match(pattern, uri) for pattern in allowed_patterns):
+            raise HTTPException(400, f"Invalid redirect URI: {uri}")
+    
+    # Store client registration
+    client = OAuth2Client(
+        client_id=client_id,
+        client_name=request.client_name or "Claude MCP Client",
+        scope=request.scope,
+        created_at=datetime.utcnow()
+    )
+    
+    # Set list properties using the custom setters
+    client.redirect_uris_list = request.redirect_uris
+    client.grant_types_list = request.grant_types
+    client.response_types_list = request.response_types
+    
+    db.add(client)
+    await db.commit()
+    
+    return ClientRegistrationResponse(
+        client_id=client_id,
+        client_id_issued_at=client_issued_at,
+        redirect_uris=request.redirect_uris,
+        grant_types=request.grant_types,
+        response_types=request.response_types,
+        token_endpoint_auth_method="none",
+        client_name=request.client_name
+    )
+
+@router.get("/oauth/authorize")
+async def oauth_authorize(
+    response_type: str = Query(...),
+    client_id: str = Query(...),
+    redirect_uri: str = Query(...),
+    scope: str = Query(default="library:read"),
+    state: Optional[str] = Query(default=None),
+    code_challenge: str = Query(...),
+    code_challenge_method: str = Query(default="S256"),
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    OAuth Authorization Endpoint
+    Redirects user to Apple Music OAuth for authentication
+    """
+    
+    # Validate client_id
+    result = await db.execute(
+        select(OAuth2Client).where(OAuth2Client.client_id == client_id)
+    )
+    client = result.scalar_one_or_none()
+    if not client:
+        raise HTTPException(400, "Invalid client_id")
+    
+    # Validate redirect_uri
+    if redirect_uri not in client.redirect_uris_list:
+        raise HTTPException(400, "Invalid redirect_uri")
+    
+    # Validate PKCE
+    if code_challenge_method != "S256":
+        raise HTTPException(400, "Only S256 code_challenge_method supported")
+    
+    # Store authorization request temporarily
+    auth_request_id = str(uuid.uuid4())
+    auth_request = AuthorizationRequest(
+        id=auth_request_id,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        scope=scope,
+        state=state or auth_request_id,  # Use auth_request_id if no state provided
+        code_challenge=code_challenge,
+        code_challenge_method=code_challenge_method,
+        expires_at=datetime.utcnow() + timedelta(minutes=10)
+    )
+    
+    db.add(auth_request)
+    await db.commit()
+    
+    # Generate developer token for MusicKit
+    from app.core.security import generate_developer_token
+    developer_token = generate_developer_token()
+    
+    # Redirect to our MusicKit authentication page
+    musickit_auth_url = f"{settings.oauth_base_url}/static/musickit-auth.html?auth_request_id={auth_request_id}&developer_token={developer_token}"
+    
+    return RedirectResponse(url=musickit_auth_url, status_code=302)
+
+@router.post("/oauth/musickit/callback")
+async def musickit_callback(
+    request: Dict[str, Any],
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    Handle MusicKit user token from JavaScript
+    This replaces the Apple OAuth callback in our hybrid approach
+    """
+    
+    auth_request_id = request.get("auth_request_id")
+    user_token = request.get("user_token")
+    
+    if not auth_request_id or not user_token:
+        raise HTTPException(400, "Missing auth_request_id or user_token")
+    
+    # Retrieve stored authorization request
+    result = await db.execute(
+        select(AuthorizationRequest).where(
+            AuthorizationRequest.id == auth_request_id,
+            AuthorizationRequest.expires_at > datetime.utcnow()
+        )
+    )
+    auth_request = result.scalar_one_or_none()
+    
+    if not auth_request:
+        raise HTTPException(400, "Invalid or expired authorization request")
+    
+    try:
+        # Generate our own authorization code for Claude
+        our_auth_code = str(uuid.uuid4())
+        
+        # Store the authorization code mapping with MusicKit user token
+        code_grant = AuthorizationCodeGrant(
+            code=our_auth_code,
+            client_id=auth_request.client_id,
+            redirect_uri=auth_request.redirect_uri,
+            scope=auth_request.scope,
+            code_challenge=auth_request.code_challenge,
+            code_challenge_method=auth_request.code_challenge_method,
+            apple_user_token=user_token,  # This is the MusicKit user token
+            apple_refresh_token=None,  # MusicKit doesn't provide refresh tokens
+            expires_at=datetime.utcnow() + timedelta(minutes=10)
+        )
+        
+        db.add(code_grant)
+        await db.commit()
+        
+        # Return redirect URL for JavaScript to handle
+        claude_callback_params = {
+            "code": our_auth_code,
+            "state": auth_request.state
+        }
+        
+        redirect_url = f"{auth_request.redirect_uri}?" + urlencode(claude_callback_params)
+        
+        return {"redirect_url": redirect_url, "status": "success"}
+        
+    except Exception as e:
+        # Return error for JavaScript to handle
+        error_params = {
+            "error": "server_error",
+            "error_description": "Failed to process MusicKit authentication",
+            "state": auth_request.state
+        }
+        
+        error_url = f"{auth_request.redirect_uri}?" + urlencode(error_params)
+        return {"redirect_url": error_url, "status": "error", "message": str(e)}
+
+@router.get("/oauth/apple/callback")
+async def apple_oauth_callback(
+    code: str = Query(...),
+    state: str = Query(...),  # This is our auth_request_id
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    Handle callback from Apple Music OAuth
+    Exchange Apple code for user token, then redirect back to Claude
+    """
+    
+    # Retrieve stored authorization request
+    result = await db.execute(
+        select(AuthorizationRequest).where(
+            AuthorizationRequest.id == state,
+            AuthorizationRequest.expires_at > datetime.utcnow()
+        )
+    )
+    auth_request = result.scalar_one_or_none()
+    
+    if not auth_request:
+        raise HTTPException(400, "Invalid or expired authorization request")
+    
+    try:
+        # Exchange Apple authorization code for user token
+        apple_token_response = await exchange_apple_authorization_code(code)
+        
+        # Generate our own authorization code for Claude
+        our_auth_code = str(uuid.uuid4())
+        
+        # Store the authorization code mapping
+        code_grant = AuthorizationCodeGrant(
+            code=our_auth_code,
+            client_id=auth_request.client_id,
+            redirect_uri=auth_request.redirect_uri,
+            scope=auth_request.scope,
+            code_challenge=auth_request.code_challenge,
+            code_challenge_method=auth_request.code_challenge_method,
+            apple_user_token=apple_token_response["access_token"],
+            apple_refresh_token=apple_token_response.get("refresh_token"),
+            expires_at=datetime.utcnow() + timedelta(minutes=10)
+        )
+        
+        db.add(code_grant)
+        await db.commit()
+        
+        # Redirect back to Claude with our authorization code
+        claude_callback_params = {
+            "code": our_auth_code,
+            "state": auth_request.state
+        }
+        
+        claude_callback_url = (
+            f"{auth_request.redirect_uri}?" + urlencode(claude_callback_params)
+        )
+        
+        return RedirectResponse(url=claude_callback_url, status_code=302)
+        
+    except Exception as e:
+        # Redirect to Claude with error
+        error_params = {
+            "error": "server_error",
+            "error_description": "Failed to authenticate with Apple Music",
+            "state": auth_request.state
+        }
+        
+        error_url = f"{auth_request.redirect_uri}?" + urlencode(error_params)
+        return RedirectResponse(url=error_url, status_code=302)
+
+async def exchange_apple_authorization_code(code: str) -> Dict[str, Any]:
+    """Exchange Apple authorization code for user token"""
+    import httpx
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://appleid.apple.com/auth/token",
+            data={
+                "client_id": settings.apple_client_id,
+                "client_secret": settings.apple_client_secret,
+                "code": code,
+                "grant_type": "authorization_code",
+                "redirect_uri": f"{settings.oauth_base_url}/oauth/apple/callback"
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"}
+        )
+        
+        if response.status_code != 200:
+            raise Exception(f"Apple OAuth failed: {response.text}")
+        
+        return response.json()
+
+@router.post("/oauth/token", response_model=TokenResponse)
+async def oauth_token(
+    grant_type: str = Form(...),
+    code: Optional[str] = Form(None),
+    refresh_token: Optional[str] = Form(None),
+    client_id: str = Form(...),
+    code_verifier: Optional[str] = Form(None),
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    OAuth Token Endpoint
+    Exchange authorization code or refresh token for access token
+    """
+    
+    if grant_type == "authorization_code":
+        return await handle_authorization_code_grant(
+            code, client_id, code_verifier, db
+        )
+    elif grant_type == "refresh_token":
+        return await handle_refresh_token_grant(
+            refresh_token, client_id, db
+        )
+    else:
+        raise HTTPException(400, "Unsupported grant_type")
+
+async def handle_authorization_code_grant(
+    code: str, 
+    client_id: str, 
+    code_verifier: str, 
+    db: AsyncSession
+) -> TokenResponse:
+    """Handle authorization_code grant type"""
+    
+    # Retrieve and validate authorization code
+    result = await db.execute(
+        select(AuthorizationCodeGrant).where(
+            AuthorizationCodeGrant.code == code,
+            AuthorizationCodeGrant.client_id == client_id,
+            AuthorizationCodeGrant.expires_at > datetime.utcnow()
+        )
+    )
+    code_grant = result.scalar_one_or_none()
+    
+    if not code_grant:
+        raise HTTPException(400, "Invalid or expired authorization code")
+    
+    # Verify PKCE code_verifier
+    expected_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode()).digest()
+    ).decode().rstrip('=')
+    
+    if expected_challenge != code_grant.code_challenge:
+        raise HTTPException(400, "Invalid code_verifier")
+    
+    # Generate access token with encrypted Apple token
+    access_token_payload = {
+        "sub": client_id,
+        "apple_user_token": encrypt_token(code_grant.apple_user_token),
+        "apple_refresh_token": encrypt_token(code_grant.apple_refresh_token) if code_grant.apple_refresh_token else None,
+        "scope": code_grant.scope,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + settings.access_token_lifetime,
+        "token_type": "Bearer"
+    }
+    
+    access_token = jwt.encode(
+        access_token_payload, 
+        settings.jwt_secret_key, 
+        algorithm="HS256"
+    )
+    
+    # Generate refresh token
+    refresh_token = str(uuid.uuid4())
+    
+    # Store tokens
+    token_record = AccessToken(
+        access_token_jti=str(uuid.uuid4()),
+        refresh_token=refresh_token,
+        client_id=client_id,
+        scope=code_grant.scope,
+        apple_user_token=code_grant.apple_user_token,
+        apple_refresh_token=code_grant.apple_refresh_token,
+        expires_at=datetime.utcnow() + timedelta(seconds=settings.access_token_lifetime)
+    )
+    
+    db.add(token_record)
+    
+    # Clean up authorization code
+    await db.delete(code_grant)
+    await db.commit()
+    
+    return TokenResponse(
+        access_token=access_token,
+        token_type="Bearer",
+        expires_in=settings.access_token_lifetime,
+        refresh_token=refresh_token,
+        scope=code_grant.scope
+    )
+
+async def handle_refresh_token_grant(
+    refresh_token: str,
+    client_id: str,
+    db: AsyncSession
+) -> TokenResponse:
+    """Handle refresh_token grant type"""
+    
+    # Find the refresh token
+    result = await db.execute(
+        select(AccessToken).where(
+            AccessToken.refresh_token == refresh_token,
+            AccessToken.client_id == client_id
+        )
+    )
+    token_record = result.scalar_one_or_none()
+    
+    if not token_record:
+        raise HTTPException(400, "Invalid refresh token")
+    
+    # TODO: Refresh Apple Music token if needed
+    # For now, reuse existing Apple token
+    
+    # Generate new access token
+    access_token_payload = {
+        "sub": client_id,
+        "apple_user_token": encrypt_token(token_record.apple_user_token),
+        "apple_refresh_token": encrypt_token(token_record.apple_refresh_token) if token_record.apple_refresh_token else None,
+        "scope": token_record.scope,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + settings.access_token_lifetime,
+        "token_type": "Bearer"
+    }
+    
+    new_access_token = jwt.encode(
+        access_token_payload, 
+        settings.jwt_secret_key, 
+        algorithm="HS256"
+    )
+    
+    # Update token record
+    token_record.expires_at = datetime.utcnow() + timedelta(seconds=settings.access_token_lifetime)
+    await db.commit()
+    
+    return TokenResponse(
+        access_token=new_access_token,
+        token_type="Bearer",
+        expires_in=settings.access_token_lifetime,
+        refresh_token=refresh_token,  # Reuse same refresh token
+        scope=token_record.scope
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,10 +6,27 @@ class Settings(BaseSettings):
     apple_key_id: str  
     apple_private_key_path: str = "/keys/AuthKey.p8"
     
+    # Apple Music OAuth (for user tokens)
+    apple_client_id: str
+    apple_client_secret: str
+    
     # Server Configuration
     server_host: str = "0.0.0.0"
     server_port: int = 8080
     debug: bool = False
+    oauth_base_url: str = "http://localhost:8080"
+    
+    # Database
+    database_url: str = "sqlite:///./data/apple_music.db"
+    
+    # OAuth Security
+    jwt_secret_key: str
+    token_encryption_key: str
+    
+    # Token Lifetimes
+    access_token_lifetime: int = 3600  # 1 hour
+    refresh_token_lifetime: int = 2592000  # 30 days
+    authorization_code_lifetime: int = 600  # 10 minutes
     
     # Rate Limiting
     rate_limit_requests: int = 100

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,0 +1,44 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from app.core.config import settings
+
+# Convert SQLite URL to async format
+if settings.database_url.startswith("sqlite:///"):
+    async_database_url = settings.database_url.replace("sqlite:///", "sqlite+aiosqlite:///")
+else:
+    async_database_url = settings.database_url
+
+# Create async database engine
+engine = create_async_engine(
+    async_database_url,
+    echo=settings.debug,
+    connect_args={"check_same_thread": False} if "sqlite" in async_database_url else {}
+)
+
+# Create async session factory
+AsyncSessionLocal = sessionmaker(
+    engine, class_=AsyncSession, expire_on_commit=False
+)
+
+# Create base class for models
+Base = declarative_base()
+
+async def get_db():
+    """Dependency to get async database session"""
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
+async def init_db():
+    """Initialize database tables"""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
+from cryptography.fernet import Fernet
 
 from app.core.config import settings
 
@@ -45,3 +46,29 @@ def validate_developer_token(token: str) -> bool:
         return exp > time.time()
     except:
         return False
+
+class TokenEncryption:
+    """Encrypt/decrypt sensitive tokens for database storage"""
+    
+    def __init__(self):
+        # Use the configured encryption key
+        self.cipher = Fernet(settings.token_encryption_key.encode())
+    
+    def encrypt_token(self, token: str) -> str:
+        """Encrypt sensitive token for storage"""
+        return self.cipher.encrypt(token.encode()).decode()
+    
+    def decrypt_token(self, encrypted_token: str) -> str:
+        """Decrypt token for use"""
+        return self.cipher.decrypt(encrypted_token.encode()).decode()
+
+# Utility functions for convenience
+def encrypt_token(token: str) -> str:
+    """Encrypt a token for database storage"""
+    encryption = TokenEncryption()
+    return encryption.encrypt_token(token)
+
+def decrypt_token(encrypted_token: str) -> str:
+    """Decrypt a token from database storage"""
+    encryption = TokenEncryption()
+    return encryption.decrypt_token(encrypted_token)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,3 @@
+from .oauth import OAuth2Client, AuthorizationRequest, AuthorizationCodeGrant, AccessToken
+
+__all__ = ["OAuth2Client", "AuthorizationRequest", "AuthorizationCodeGrant", "AccessToken"]

--- a/app/models/oauth.py
+++ b/app/models/oauth.py
@@ -1,0 +1,81 @@
+from sqlalchemy import Column, String, DateTime, Text, ForeignKey, Integer
+from sqlalchemy.sql import func
+from datetime import datetime
+import json
+
+from app.core.database import Base
+
+class OAuth2Client(Base):
+    __tablename__ = "oauth2_clients"
+    
+    client_id = Column(String, primary_key=True)
+    client_name = Column(String)
+    redirect_uris = Column(Text)  # JSON serialized list
+    grant_types = Column(Text)    # JSON serialized list
+    response_types = Column(Text) # JSON serialized list
+    scope = Column(String)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+    
+    @property
+    def redirect_uris_list(self):
+        return json.loads(self.redirect_uris) if self.redirect_uris else []
+    
+    @redirect_uris_list.setter
+    def redirect_uris_list(self, value):
+        self.redirect_uris = json.dumps(value)
+    
+    @property
+    def grant_types_list(self):
+        return json.loads(self.grant_types) if self.grant_types else []
+    
+    @grant_types_list.setter
+    def grant_types_list(self, value):
+        self.grant_types = json.dumps(value)
+    
+    @property
+    def response_types_list(self):
+        return json.loads(self.response_types) if self.response_types else []
+    
+    @response_types_list.setter
+    def response_types_list(self, value):
+        self.response_types = json.dumps(value)
+
+class AuthorizationRequest(Base):
+    __tablename__ = "authorization_requests"
+    
+    id = Column(String, primary_key=True)
+    client_id = Column(String, ForeignKey("oauth2_clients.client_id"))
+    redirect_uri = Column(String)
+    scope = Column(String)
+    state = Column(String)
+    code_challenge = Column(String)
+    code_challenge_method = Column(String)
+    expires_at = Column(DateTime)
+    created_at = Column(DateTime, default=func.now())
+
+class AuthorizationCodeGrant(Base):
+    __tablename__ = "authorization_code_grants"
+    
+    code = Column(String, primary_key=True)
+    client_id = Column(String, ForeignKey("oauth2_clients.client_id"))
+    redirect_uri = Column(String)
+    scope = Column(String)
+    code_challenge = Column(String)
+    code_challenge_method = Column(String)
+    apple_user_token = Column(Text)
+    apple_refresh_token = Column(Text)
+    expires_at = Column(DateTime)
+    created_at = Column(DateTime, default=func.now())
+
+class AccessToken(Base):
+    __tablename__ = "access_tokens"
+    
+    access_token_jti = Column(String, primary_key=True)
+    refresh_token = Column(String, unique=True)
+    client_id = Column(String, ForeignKey("oauth2_clients.client_id"))
+    scope = Column(String)
+    apple_user_token = Column(Text)
+    apple_refresh_token = Column(Text)
+    expires_at = Column(DateTime)
+    created_at = Column(DateTime, default=func.now())

--- a/app/static/musickit-auth.html
+++ b/app/static/musickit-auth.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="origin" />
+    <title>Apple Music Authentication</title>
+    <script src="https://js-cdn.music.apple.com/musickit/v3/musickit.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display",
+          "Segoe UI", Roboto, sans-serif;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px;
+      }
+
+      .container {
+        background: rgba(255, 255, 255, 0.1);
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 24px;
+        padding: 48px;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+        max-width: 480px;
+        width: 100%;
+        text-align: center;
+      }
+
+      .logo {
+        font-size: 64px;
+        margin-bottom: 24px;
+        animation: float 3s ease-in-out infinite;
+      }
+
+      @keyframes float {
+        0%,
+        100% {
+          transform: translateY(0);
+        }
+        50% {
+          transform: translateY(-10px);
+        }
+      }
+
+      h1 {
+        font-size: 32px;
+        font-weight: 600;
+        margin-bottom: 12px;
+      }
+
+      .subtitle {
+        opacity: 0.9;
+        margin-bottom: 40px;
+        font-size: 17px;
+        line-height: 1.4;
+      }
+
+      .button {
+        background: linear-gradient(135deg, #ff416c, #ff4b2b);
+        border: none;
+        color: white;
+        padding: 16px 32px;
+        font-size: 17px;
+        font-weight: 500;
+        border-radius: 100px;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        box-shadow: 0 4px 15px rgba(255, 65, 108, 0.3);
+        margin: 8px;
+        min-width: 220px;
+      }
+
+      .button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 8px 25px rgba(255, 65, 108, 0.4);
+      }
+
+      .button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        transform: none;
+        background: linear-gradient(135deg, #718096, #4a5568);
+        box-shadow: none;
+      }
+
+      .status {
+        margin: 24px 0;
+        padding: 16px 24px;
+        border-radius: 12px;
+        font-weight: 500;
+        font-size: 15px;
+        min-height: 56px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .status.loading {
+        background: rgba(52, 152, 219, 0.15);
+        border: 1px solid rgba(52, 152, 219, 0.3);
+      }
+
+      .status.success {
+        background: rgba(39, 174, 96, 0.15);
+        border: 1px solid rgba(39, 174, 96, 0.3);
+      }
+
+      .status.error {
+        background: rgba(231, 76, 60, 0.15);
+        border: 1px solid rgba(231, 76, 60, 0.3);
+      }
+
+      .spinner {
+        display: inline-block;
+        width: 16px;
+        height: 16px;
+        border: 2px solid rgba(255, 255, 255, 0.3);
+        border-radius: 50%;
+        border-top-color: white;
+        animation: spin 0.8s linear infinite;
+        margin-right: 12px;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      @media (max-width: 480px) {
+        .container {
+          padding: 32px 24px;
+        }
+        h1 {
+          font-size: 28px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="logo">🎵</div>
+      <h1>Connect to Apple Music</h1>
+      <p class="subtitle">
+        Authorize Claude to access your Apple Music library
+      </p>
+
+      <div id="status" class="status loading">
+        <span class="spinner"></span>
+        <span>Initializing...</span>
+      </div>
+
+      <button id="authorizeBtn" class="button" disabled>
+        Connect Apple Music
+      </button>
+    </div>
+
+    <script>
+      // Get URL parameters
+      const urlParams = new URLSearchParams(window.location.search);
+      const authRequestId = urlParams.get("auth_request_id");
+      const developerToken = urlParams.get("developer_token");
+
+      // Elements
+      const statusEl = document.getElementById("status");
+      const authorizeBtn = document.getElementById("authorizeBtn");
+
+      // Global music instance
+      let music = null;
+
+      // Update status display
+      function updateStatus(message, type = "loading") {
+        statusEl.className = `status ${type}`;
+        if (type === "loading") {
+          statusEl.innerHTML = `<span class="spinner"></span><span>${message}</span>`;
+        } else {
+          statusEl.innerHTML = `<span>${message}</span>`;
+        }
+      }
+
+      // Wait for MusicKit instance with retry
+      async function waitForMusicKitInstance(maxAttempts = 20) {
+        for (let i = 0; i < maxAttempts; i++) {
+          try {
+            const instance = MusicKit.getInstance();
+            if (instance) {
+              console.log(`Got MusicKit instance on attempt ${i + 1}`);
+              return instance;
+            }
+          } catch (e) {
+            // Ignore errors, just keep trying
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        throw new Error(
+          "MusicKit instance not available after " + maxAttempts + " attempts"
+        );
+      }
+
+      // Initialize MusicKit
+      async function initializeMusicKit() {
+        if (!authRequestId || !developerToken) {
+          updateStatus("❌ Missing authentication parameters", "error");
+          return;
+        }
+
+        try {
+          // Configure MusicKit
+          MusicKit.configure({
+            developerToken: developerToken,
+            app: {
+              name: "Apple Music MCP Server",
+              build: "1.0.0",
+            },
+          });
+
+          console.log("MusicKit configured, waiting for instance...");
+          updateStatus("Preparing Apple Music...", "loading");
+
+          // Wait for instance to be available
+          music = await waitForMusicKitInstance();
+
+          // Check if already authorized
+          if (music.isAuthorized) {
+            updateStatus("✅ Already connected! Click to continue.", "success");
+            authorizeBtn.textContent = "Continue";
+          } else {
+            updateStatus("Ready to connect", "success");
+          }
+
+          authorizeBtn.disabled = false;
+        } catch (error) {
+          console.error("MusicKit initialization error:", error);
+          updateStatus(`❌ ${error.message}`, "error");
+        }
+      }
+
+      // Handle authorization
+      async function handleAuthorization() {
+        if (!music) return;
+
+        try {
+          authorizeBtn.disabled = true;
+          updateStatus("Connecting to Apple Music...", "loading");
+
+          // Get user token
+          const userToken = await music.authorize();
+
+          if (!userToken) {
+            throw new Error("No user token received");
+          }
+
+          console.log(
+            "User token received:",
+            userToken.substring(0, 20) + "..."
+          );
+          updateStatus("Completing setup...", "loading");
+
+          // Send token to server
+          const response = await fetch("/oauth/musickit/callback", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              auth_request_id: authRequestId,
+              user_token: userToken,
+            }),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Server error: ${response.status}`);
+          }
+
+          const result = await response.json();
+          updateStatus("🎉 Success! Redirecting...", "success");
+
+          // Redirect after a short delay
+          if (result.redirect_url) {
+            setTimeout(() => {
+              window.location.href = result.redirect_url;
+            }, 1500);
+          } else {
+            updateStatus("✅ Complete! You can close this window.", "success");
+          }
+        } catch (error) {
+          console.error("Authorization error:", error);
+
+          let message = "Authorization failed";
+          if (error.message.includes("popup")) {
+            message = "Pop-up blocked. Please allow pop-ups and try again.";
+          } else if (error.message.includes("cancel")) {
+            message = "Authorization cancelled.";
+          } else if (error.message.includes("Server error")) {
+            message = error.message;
+          }
+
+          updateStatus(`❌ ${message}`, "error");
+          authorizeBtn.disabled = false;
+          authorizeBtn.textContent = "Try Again";
+        }
+      }
+
+      // Event listeners
+      authorizeBtn.addEventListener("click", handleAuthorization);
+
+      // Wait for MusicKit to load
+      document.addEventListener("musickitloaded", () => {
+        console.log("MusicKit loaded");
+        initializeMusicKit();
+      });
+
+      // Timeout if MusicKit doesn't load
+      setTimeout(() => {
+        if (!window.MusicKit) {
+          updateStatus("❌ MusicKit failed to load. Please refresh.", "error");
+        }
+      }, 10000);
+    </script>
+  </body>
+</html>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,11 +9,8 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-    environment:
-      - APPLE_TEAM_ID=${APPLE_TEAM_ID}
-      - APPLE_KEY_ID=${APPLE_KEY_ID}
-      - APPLE_PRIVATE_KEY_PATH=/keys/AuthKey.p8
-      - DEBUG=false
+    env_file:
+      - ../.env
     volumes:
       - ./keys:/keys:ro
     networks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,19 @@ httpx==0.25.2
 pyjwt[crypto]==2.8.0
 cryptography>=41.0.0
 
+# Database
+sqlalchemy==2.0.23
+alembic==1.12.1
+aiosqlite==0.19.0
+
 # Configuration
 pydantic==2.5.0
 pydantic-settings==2.1.0
 
 # Utilities
 python-multipart==0.0.6
+python-jose[cryptography]==3.3.0
+slowapi==0.1.9
 
 # Development
 pytest==7.4.3


### PR DESCRIPTION
- Add MusicKit authentication web page for user token acquisition
- Update OAuth authorize endpoint to redirect to MusicKit instead of Apple OAuth
- Add musickit callback endpoint to handle JavaScript user tokens
- Fix MCP handler to extract user tokens from OAuth Bearer headers
- Update main.py to pass authorization headers to MCP tool calls
- Fix HTTP client lifecycle issues in Apple Music client
- Add static file serving and database initialization to main app
- Update docker-compose to use .env file for configuration

OAuth flow now complete: registration → authorization → MusicKit auth → token exchange → MCP access